### PR TITLE
Add docker-compose for Mongo

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,6 @@
+version: '2'
+services:
+  mongo:
+    image: mongo
+    ports:
+      - "27017:27017"


### PR DESCRIPTION
I don't have Mongo installed locally, and this lets me just run `docker-compose up` and be good to go with Mongo for now until we switch to another data store. 